### PR TITLE
Added `prefer_sparql` attribute to backends

### DIFF
--- a/pybacktrip/backends/fuseki.py
+++ b/pybacktrip/backends/fuseki.py
@@ -25,6 +25,7 @@ class FusekiStrategy:
 
     __namespaces = {}
     __sparql_endpoint = ""
+    prefer_sparql = True  # prefer tripper.query() over tripper.triples()
 
     # DEFAULT METHODS
 

--- a/pybacktrip/backends/stardog.py
+++ b/pybacktrip/backends/stardog.py
@@ -24,6 +24,7 @@ class StardogStrategy:
     __file_extension = {"turtle": ".ttl", "rdf": ".rdf"}
 
     __sparql_endpoints = {}
+    prefer_sparql = True  # prefer tripper.query() over tripper.triples()
 
     def __init__(
         self, base_iri: str, triplestore_url: str, database: str, **kwargs


### PR DESCRIPTION
This attribute tells tripper whether the backend prefers the tripper.query() or tripper.triples() interface. 

**Note**: Running `pre-commit` produces a lot of warnings. I did not fix them, but it might be a good idea to go through them.

